### PR TITLE
Escape \ and " in JSON strings

### DIFF
--- a/json.applescript
+++ b/json.applescript
@@ -26,7 +26,11 @@ end
 on encodeString(value)
 	set rv to ""
 	repeat with ch in value
-		if id of ch >= 32 and id of ch < 127
+		if id of ch = 34
+			set quoted_ch to "\\\""
+		else if id of ch = 92 then
+			set quoted_ch to "\\\\"
+		else if id of ch >= 32 and id of ch < 127
 			set quoted_ch to ch
 		else
 			set quoted_ch to "\\u" & hex4(id of ch)

--- a/tests.applescript
+++ b/tests.applescript
@@ -32,6 +32,8 @@ assert_eq(json's encode("foo"), "\"foo\"")
 assert_eq(json's encode(""), "\"\"")
 assert_eq(json's encode("\n"), "\"\\u000a\"")
 assert_eq(json's encode("ș"), "\"\\u0219\"")
+assert_eq(json's encode("\"bar\""), "\"\\\"bar\\\"\"")
+assert_eq(json's encode("\\"), "\"\\\\\"")
 
 assert_eq(json's encode({1, 2, 3}), "[1, 2, 3]")
 


### PR DESCRIPTION
applescript-json's string encoding capability should be 100% compliant now. Nice!

As per the official standard ([ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf), p 10):

> All characters may be placed within the quotation marks except for the
> characters that must be escaped: quotation mark (U+0022), reverse solidus
> (U+005C), and the control characters U+0000 to U+001F.
