### PR TITLE
Add support for combining characters

### DIFF
--- a/json.applescript
+++ b/json.applescript
@@ -25,15 +25,22 @@ end
 
 on encodeString(value)
 	set rv to ""
-	repeat with ch in value
-		if id of ch = 34
+	set codepoints to id of value
+
+	if (class of codepoints) is not list
+		set codepoints to {codepoints}
+	end
+
+	repeat with codepoint in codepoints
+		set codepoint to codepoint as integer
+		if codepoint = 34
 			set quoted_ch to "\\\""
-		else if id of ch = 92 then
+		else if codepoint = 92 then
 			set quoted_ch to "\\\\"
-		else if id of ch >= 32 and id of ch < 127
-			set quoted_ch to ch
+		else if codepoint >= 32 and codepoint < 127
+			set quoted_ch to character id codepoint
 		else
-			set quoted_ch to "\\u" & hex4(id of ch)
+			set quoted_ch to "\\u" & hex4(codepoint)
 		end
 		set rv to rv & quoted_ch
 	end

--- a/tests.applescript
+++ b/tests.applescript
@@ -32,6 +32,7 @@ assert_eq(json's encode("foo"), "\"foo\"")
 assert_eq(json's encode(""), "\"\"")
 assert_eq(json's encode("\n"), "\"\\u000a\"")
 assert_eq(json's encode("ș"), "\"\\u0219\"")
+assert_eq(json's encode("u" & "̈"), "\"u\\u0308\"")
 assert_eq(json's encode("\"bar\""), "\"\\\"bar\\\"\"")
 assert_eq(json's encode("\\"), "\"\\\\\"")
 


### PR DESCRIPTION
In Unicode, a combining character is a character which can be stacked on top of the character preceding it. For example:

## Example

- The character LATIN SMALL LETTER U (`u`) has the codepoint U+0075 assigned.
- The character COMBINING DIAERESIS, which looks similar to the symbol `¨` but is actually a combining character, has the codepoint U+0308 assigned.
- Writing both characters in sequence yields the letter `ü`, which looks just like `ü` but is actually *two* characters.

## Impact

On a Mac, such combinations are very common, especially in filenames due to [an oddity in the HFS+ filesystem](http://dubeiko.com/development/FileSystems/HFSPLUS/tn1150.html#CanonicalDecomposition).

## The issue

In the `applescript-json` library however, the `encodeString` function **always fails when the input contains a combining character.**
In detail, the code assumes that inside the `repeat with ch` loop, `ch` will be always one single character, and its `id` property will always return an integer. However, in reality `ch` will contain more than one character if a combining character is involved. Because of that, the `id` property will return a list instead of an integer. The code is not prepared to handle the list, which triggers the error.

## The fix

**This PR fixes the issue** by fetching `id` before doing the iteration. This yields a simple list of all codepoints in the entire input string, which can be iterated safely. I have also added a simple test case for the “u followed by   ̈ ” scenario described above (including the expected JSON output, which would be `u\u0308`).
